### PR TITLE
`os.chmod` error in containers

### DIFF
--- a/CIRIquant/main.py
+++ b/CIRIquant/main.py
@@ -129,7 +129,10 @@ def main():
     # Add lib to PATH
     lib_path = os.path.dirname(os.path.split(os.path.realpath(__file__))[0]) + '/libs'
     os.environ['PATH'] = lib_path + ':' + os.environ['PATH']
-    #os.chmod(lib_path + '/CIRI2.pl', 0o755)
+    try:
+        os.chmod(lib_path + '/CIRI2.pl', 0o755)
+    except OSError:
+        pass
 
     """Start Running"""
     os.chdir(outdir)

--- a/CIRIquant/main.py
+++ b/CIRIquant/main.py
@@ -129,7 +129,7 @@ def main():
     # Add lib to PATH
     lib_path = os.path.dirname(os.path.split(os.path.realpath(__file__))[0]) + '/libs'
     os.environ['PATH'] = lib_path + ':' + os.environ['PATH']
-    os.chmod(lib_path + '/CIRI2.pl', 0o755)
+    #os.chmod(lib_path + '/CIRI2.pl', 0o755)
 
     """Start Running"""
     os.chdir(outdir)


### PR DESCRIPTION
Hi Jinyang, 

Containerised versions of `CIRIquant` fail during runtime due to the following error:

```console
Command error:
  Traceback (most recent call last):
    File "/usr/local/bin/CIRIquant", line 10, in <module>
      sys.exit(main())
    File "/usr/local/lib/python2.7/site-packages/CIRIquant/main.py", line 126, in main
      os.chmod(lib_path + '/CIRI2.pl', 0o755)
  OSError: [Errno 1] Operation not permitted: '/usr/local/lib/python2.7/site-packages/libs/CIRI2.pl'
```

The solution is to comment line 132 (or 126 in your release) in `CIRIquant/main.py`:

```console
os.chmod(lib_path + '/CIRI2.pl', 0o755)
```

I have observed this behaviour in versions 1.0.0 and 1.1.2. 